### PR TITLE
fix/SPRIND-138

### DIFF
--- a/sphereon-kmp-mdoc-core/src/commonMain/kotlin/com/sphereon/mdoc/data/device/Document.kt
+++ b/sphereon-kmp-mdoc-core/src/commonMain/kotlin/com/sphereon/mdoc/data/device/Document.kt
@@ -130,7 +130,7 @@ data class DocumentCbor(
         deviceSigned: DeviceSignedCbor? = null
     ): DocumentCbor {
         val docRequest = Oid4VPPresentationDefinition.Static.fromDTO(presentationDefinition).toDocRequest()
-        if (docRequest.itemsRequest.docType !== this.docType) {
+        if (docRequest.itemsRequest.docType != this.docType) {
             throw IllegalArgumentException("Document request docType ${docRequest.itemsRequest.docType} does not match docType ${this.docType}")
         }
         return DocumentCbor(docType = this.docType, issuerSigned = limitDisclosures(docRequest), deviceSigned = deviceSigned ?: this.deviceSigned)


### PR DESCRIPTION
 use structural equality instead of referential equality to check doc types in limitDisclosureFromPresentationDefinition